### PR TITLE
chore(Dockerfile): bump alpine base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.3
+FROM alpine:3.5
 
 RUN apk add -U \
 	bash \


### PR DESCRIPTION
with `alpine:3.3`:
```
$ docker build .
Sending build context to Docker daemon  76.8 kB
Step 1/9 : FROM alpine:3.3
 ---> 6c2aa2137d97
Step 2/9 : RUN apk add -U 	bash 	nginx 	&& rm -rf /var/cache/apk*
 ---> Running in 679221a7f9a6
fetch http://dl-cdn.alpinelinux.org/alpine/v3.3/main/x86_64/APKINDEX.tar.gz
fetch http://dl-cdn.alpinelinux.org/alpine/v3.3/community/x86_64/APKINDEX.tar.gz
ERROR: unsatisfiable constraints:
  bash (missing):
    required by: world[bash]
The command '/bin/sh -c apk add -U 	bash 	nginx 	&& rm -rf /var/cache/apk*' returned a non-zero code: 1
```

(builds successfully from `alpine:3.5`)